### PR TITLE
Fixes problems with classroom prediction views.

### DIFF
--- a/src/js/components/class-view.tsx
+++ b/src/js/components/class-view.tsx
@@ -3,7 +3,19 @@ import { Tabs, Tab } from "material-ui/Tabs";
 import { Card, CardMedia, CardTitle } from "material-ui/Card";
 import { SimPrefs } from "../sim-prefs";
 import { LeafletMapView } from "./leaflet-map-view";
+import { PredictionShareView } from "./prediction-share-view";
+import { ComponentStyleMap } from "../component-style-map";
+
 import { dataStore } from "../data-store";
+
+const styles:ComponentStyleMap = {
+  mapAndPrediction: {
+    display: "flex",
+    flexDirection: "row",
+    overflow: "hidden",
+    maxWidth: "90vw"
+  }
+};
 
 export interface ClassViewProps {
   frame: number;
@@ -32,13 +44,16 @@ export class ClassView extends React.Component<ClassViewProps, ClassViewstate> {
                 alignItems: "center"
               }}
             >
-              <LeafletMapView
-                mapConfig={dataStore.mapConfig}
-                interaction={false}
-                baseStations={dataStore.basestations}
-                width={800}
-                height={600}
-              />
+              <div style={styles.mapAndPrediction}>
+                <LeafletMapView
+                  mapConfig={dataStore.mapConfig}
+                  interaction={false}
+                  baseStations={dataStore.basestations}
+                  width={"60vw"}
+                  height={"600"}
+                />
+                <PredictionShareView/>
+              </div>
             </CardMedia>
           </Tab>
         </Tabs>

--- a/src/js/components/leaflet-map-view.tsx
+++ b/src/js/components/leaflet-map-view.tsx
@@ -8,8 +8,8 @@ import { Basestation } from "../basestation";
 import { LeafletMapMarker } from "./leaflet-map-marker";
 interface LeafletMapProps {
   mapConfig: MapConfig | null;
-  width: number;
-  height: number;
+  width: string;
+  height: string;
   interaction: boolean;
   baseStations: Basestation[];
   update?: (lat: number, long: number, zoom: number) => void;

--- a/src/js/components/prediction-share-view.tsx
+++ b/src/js/components/prediction-share-view.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { observer } from "mobx-react";
+import { ComponentStyleMap } from "../component-style-map";
+import { dataStore } from "../data-store";
+import { NullPredictionView } from "../null-prediction-view-obj";
+
+const styles:ComponentStyleMap = {
+  prediction: {
+    display: "flex",
+    flexDirection: "column",
+    padding: "0em 2em",
+    width: "20vw"
+  },
+  callsign: {
+    fontSize: "16pt",
+    fontWeight: "bold"
+  },
+  stationName: {
+    fontSize: "10pt"
+  },
+  values: {
+    marginTop: "1em"
+  },
+  temp: {
+    fontSize: "12pt",
+    fontWeight: "bold"
+  },
+  label: {
+    fontSize: "9pt",
+    fontStyle: "italic",
+    marginTop: "1em"
+  },
+  rationale: {
+    fontSize: "13pt"
+  },
+  image: {
+    height: "10vh"
+  }
+};
+
+export interface PredictionShareViewProps {}
+export interface PredictionShareViewState {}
+
+@observer
+export class PredictionShareView extends React.Component<
+  PredictionShareViewProps,
+  PredictionShareViewState
+> {
+  interval: any;
+
+  constructor(props: PredictionShareViewProps, ctxt: any) {
+    super(props, ctxt);
+  }
+
+  render() {
+    const selectedBasestation = dataStore.selectedBasestation;
+    const prediction = dataStore.selectedPrediction || NullPredictionView;
+    if(selectedBasestation) {
+      return(
+        <div style={styles.prediction}>
+          <div>
+            <img style={styles.image} src={selectedBasestation.imageUrl}/>
+            <div style={styles.callsign}>{selectedBasestation.callsign}</div>
+            <div style={styles.stationName}>{selectedBasestation.name}</div>
+            <div style={styles.values}>
+              <div>
+                <span style={styles.label}>Predicted Temp: </span>
+                <span style={styles.temp}>{prediction.temp}°</span>
+              </div>
+              <div style={styles.label}>Reasoning:</div>
+              <div style={styles.rationale}>{prediction.rationale}</div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+
+}
+

--- a/src/js/components/setup-map-view.tsx
+++ b/src/js/components/setup-map-view.tsx
@@ -89,8 +89,8 @@ export class SetupMapView extends React.Component<
             mapConfig={dataStore.editingMap}
             interaction={true}
             baseStations={dataStore.basestations}
-            width={600}
-            height={400}
+            width={"600"}
+            height={"400"}
             update={(lat, long, zoom) => {
               mapConfig.lat = lat;
               mapConfig.long = long;
@@ -151,8 +151,8 @@ export class SetupMapView extends React.Component<
                     mapConfig={map}
                     interaction={false}
                     baseStations={dataStore.basestations}
-                    width={600}
-                    height={400}
+                    width={"600"}
+                    height={"400"}
                   />
                 </div>
               </div>

--- a/src/js/components/teacher-view.tsx
+++ b/src/js/components/teacher-view.tsx
@@ -7,6 +7,8 @@ import { LeafletMapView } from "./leaflet-map-view";
 import { TeacherOptionsView } from "./teacher-options-view";
 import { ComponentStyleMap } from "../component-style-map";
 import { dataStore } from "../data-store";
+import { NullPredictionView } from "../null-prediction-view-obj";
+import { PredictionShareView } from "./prediction-share-view";
 
 export type TeacherViewTab = "control" | "configure";
 
@@ -25,37 +27,6 @@ const styles:ComponentStyleMap = {
     flexDirection: "row",
     overflow: "hidden",
     maxWidth: "90vw"
-  },
-  prediction: {
-    display: "flex",
-    flexDirection: "column",
-    padding: "0em 2em",
-    width: "20vw"
-  },
-  callsign: {
-    fontSize: "16pt",
-    fontWeight: "bold"
-  },
-  stationName: {
-    fontSize: "10pt"
-  },
-  values: {
-    marginTop: "1em"
-  },
-  temp: {
-    fontSize: "12pt",
-    fontWeight: "bold"
-  },
-  label: {
-    fontSize: "9pt",
-    fontStyle: "italic",
-    marginTop: "1em"
-  },
-  rationale: {
-    fontSize: "13pt"
-  },
-  image: {
-    height: "10vh"
   }
 };
 
@@ -95,27 +66,6 @@ export class TeacherView extends React.Component<
     dataStore.setFrame(0);
   }
 
-  renderPrediction() {
-    if(dataStore.basestation) {
-      return(
-        <div>
-          <img style={styles.image} src={dataStore.basestation.imageUrl}/>
-          <div style={styles.callsign}>{dataStore.basestation.callsign}</div>
-          <div style={styles.stationName}>{dataStore.basestation.name}</div>
-          <div style={styles.values}>
-            <div>
-              <span style={styles.label}>Temp:</span>
-              <span style={styles.temp}>{dataStore.prediction.temp}°</span>
-            </div>
-            <div style={styles.label}>Reasoning:</div>
-            <div style={styles.rationale}>{dataStore.prediction.rationale}</div>
-          </div>
-        </div>
-      );
-    }
-    return null;
-  }
-
   render() {
     const rewind = this.rewind.bind(this);
     const play = this.play.bind(this);
@@ -151,12 +101,10 @@ export class TeacherView extends React.Component<
                   mapConfig={dataStore.mapConfig}
                   interaction={false}
                   baseStations={dataStore.basestations}
-                  width={600}
-                  height={400}
+                  width={"600"}
+                  height={"400"}
                 />
-                <div style={styles.prediction}>
-                  {this.renderPrediction()}
-                </div>
+                <PredictionShareView/>
               </div>
               <CardActions>
                 <FloatingActionButton

--- a/src/js/data-store.ts
+++ b/src/js/data-store.ts
@@ -43,6 +43,7 @@ export interface FireBaseState {
   presence?: PresenceMap;
   basestations?: BasestationMap;
   mapConfigs?: MapConfigMap;
+  selectedBasestationId?: string;
 }
 
 class DataStore {
@@ -137,6 +138,9 @@ class DataStore {
     } else {
       this.mapConfigMap = observable({} as MapConfigMap);
     }
+    if (newState.selectedBasestationId) {
+      this.selectedBasestationId = newState.selectedBasestationId;
+    }
   }
 
   @computed
@@ -191,6 +195,14 @@ class DataStore {
     }
     return null;
   }
+  @computed
+  get selectedPrediction() {
+    const base = this.selectedBasestation;
+    if(base) {
+      return this.predictions[base.id];
+    }
+    return null;
+  }
   set selectedBasestation(basestation:Basestation|null) {
     if(basestation) {
       this.selectedBasestationId = basestation.id;
@@ -198,6 +210,7 @@ class DataStore {
     else {
       this.selectedBasestationId = null;
     }
+    this.saveToPath('selectedBasestationId',this.selectedBasestationId);
   }
 
   @computed

--- a/src/js/null-prediction-view-obj.ts
+++ b/src/js/null-prediction-view-obj.ts
@@ -1,0 +1,5 @@
+export const NullPredictionView = {
+  id: 10,
+  temp: "-",
+  rationale: "-"
+};


### PR DESCRIPTION
We are about to blow-away most of this code, but I thought I would commit this fix before we got started on the MST  work.

Previously the datastore had a computed reference to `get basestation` -- this basestation was unique to every user of the system. The primary use case being the basestation views.  

Now there is a `get selectedBasestation` -- which is shared by all the users of the current simulation.  It represents the basestation selected for display in the classroom.

A shared component for viewing predictions was extracted to DRY up teacher / classroom views.
