### PR TITLE
Fix data silo bug

### DIFF
--- a/src/code/middleware/firebase-decorator.ts
+++ b/src/code/middleware/firebase-decorator.ts
@@ -15,11 +15,11 @@ export const Firebasify = (model:any, relativeDataPath:string, callBack?:()=> vo
       updateFunc(newV);
       ref.on('value',updateFunc);
       onSnapshot(model, (newSnapshot:any) => {
-        const data = _.clone(newSnapshot);
+        let data = _.clone(newSnapshot);
         if(model.filterOutboundData) {
-          model.filterOutboundData(data);
+          data = model.filterOutboundData(data);
         }
-        ref.update(newSnapshot);
+        ref.update(data);
       });
       if(callBack) {
         setTimeout( ()=> {

--- a/src/code/middleware/firebase-decorator.ts
+++ b/src/code/middleware/firebase-decorator.ts
@@ -1,6 +1,5 @@
 import { onSnapshot, applySnapshot } from "mobx-state-tree";
 import { gFirebase, FirebaseData, FirebaseRef} from "./firebase-imp";
-import * as _ from "lodash";
 
 export const Firebasify = (model:any, relativeDataPath:string, callBack?:()=> void) => {
   const pendingRef = gFirebase.refForPath(relativeDataPath);
@@ -15,10 +14,7 @@ export const Firebasify = (model:any, relativeDataPath:string, callBack?:()=> vo
       updateFunc(newV);
       ref.on('value',updateFunc);
       onSnapshot(model, (newSnapshot:any) => {
-        let data = _.clone(newSnapshot);
-        if(model.filterOutboundData) {
-          data = model.filterOutboundData(data);
-        }
+        const data = model.filterOutboundData ? model.filterOutboundData(newSnapshot) : newSnapshot;
         ref.update(data);
       });
       if(callBack) {

--- a/src/code/models/simulation.ts
+++ b/src/code/models/simulation.ts
@@ -163,7 +163,7 @@ export const Simulation = types.model('Simulation', {
   },
   filterOutboundData(snapshot:any) {
     let copy = _.cloneDeep(snapshot);
-    const studentRemoveKeys= ["control", "settings", "scenario", "grid", "stations"];
+    const studentRemoveKeys= ["control", "settings"];
     const teacherRemoveKeys= ["presences"];
     // remove keys from object.
     const remove = (obj:any, keys:string[]) => {


### PR DESCRIPTION

@kswenson I moved this work to a new PR, because my last one was on the wrong branch.

In addition to the simplification you suggested, I also allow students to write to scenario, grid, and stations, because if a student launches a scenario first, they will have to populate those simulation items.