### PR TITLE
Simplify pause/resume functionality

### DIFF
--- a/src/code/views/segmented-control-view.tsx
+++ b/src/code/views/segmented-control-view.tsx
@@ -20,8 +20,8 @@ export class SegmentedControlView extends React.Component<
   render() {
     const simulation = simulationStore.selected;
     const isPlaying = !!(simulation && simulation.isPlaying);
-    const playFirstHalf = () =>  simulation.playFirstHalf();
-    const playSecondHalf = () => simulation.playSecondHalf();
+    // const playFirstHalf = () =>  simulation.playFirstHalf();
+    // const playSecondHalf = () => simulation.playSecondHalf();
     const reset = () => simulation.rewind();
     // disable dragging (at least for now)
     // const dragStop = (o:any) => {
@@ -38,6 +38,10 @@ export class SegmentedControlView extends React.Component<
     const endTime = simulation && simulation.endTime;
     const halfTime = simulation && simulation.halfTime;
     const currentTime = simulation && simulation.time;
+    const isAtBeginning = currentTime && startTime && currentTime <= startTime;
+    const isAtEnd = currentTime && endTime && currentTime >= endTime;
+    const playPauseIcon = isPlaying ? "icon-pause" : "icon-play_arrow";
+    const playPauseAction = isPlaying ? simulation.stop : simulation.play;
     const style:ComponentStyleMap = {
       container: {
         display: "flex",
@@ -45,26 +49,33 @@ export class SegmentedControlView extends React.Component<
         maxWidth: 500,
         height: 110,
         alignItems: "center"
+      },
+      buttonStyle: {
+        padding: "0 4px"
+      },
+      iconStyle: {
+        color: "#FFF",
+        fontSize: 24
       }
     };
     return(
       <div style={style.container} >
           <div>
             <RaisedButton
-              disabled={isPlaying}
+              style={style.buttonStyle}
+              disabled={!simulation || isAtBeginning || isPlaying}
               onTouchTap={reset}
+              icon={<i className="icon-refresh" style={style.iconStyle} />}
               label="Reset"
               primary={true}
             />
             <RaisedButton
-              disabled={isPlaying}
-              onTouchTap={playFirstHalf}
-              label="Run first portion"
-            />
-            <RaisedButton
-              disabled={isPlaying}
-              onTouchTap={playSecondHalf}
-              label="Run second portion"
+              buttonStyle={style.buttonStyle}
+              disabled={!simulation || isAtEnd}
+              onTouchTap={playPauseAction}
+              icon={<i className={playPauseIcon} style={style.iconStyle} />}
+              label={isPlaying ? "Pause" : "Play"}
+              primary={true}
             />
           </div>
           <TimelineView

--- a/src/code/views/teacher-view.tsx
+++ b/src/code/views/teacher-view.tsx
@@ -7,7 +7,7 @@ import { GridView } from "./grid-view";
 import { weatherColor, precipDiv } from "./weather-styler";
 import { LeafletMapView } from "./leaflet-map-view";
 // import { PlaybackOptionsView } from "./playback-options-view";
-import { PlaybackControlView } from "./playback-control-view";
+// import { PlaybackControlView } from "./playback-control-view";
 import { SegmentedControlView } from "./segmented-control-view";
 import { ComponentStyleMap } from "../utilities/component-style-map";
 //import { TeacherOptionsView } from "./teacher-options-view";
@@ -206,7 +206,7 @@ export class TeacherView extends React.Component<
                   */}
                 </div>
                   <SegmentedControlView />
-                  <PlaybackControlView />
+                  {/* <PlaybackControlView /> */}
                 {/*
                   import { PredictionSelectorView } from "../prediction-selection-view"
                   <PredictionSelectorView />


### PR DESCRIPTION
Implement pause/resume button in segmented control [#154025717]
- remove play first/second section buttons
- remove VCR-style playback controls [#154025648]

Note: This is different than what was suggested in the [PT story](https://www.pivotaltracker.com/story/show/154025717). One of the goals of the latest round of changes is to simplify the interface, and yet following the recommendation of this story would result in three play buttons and an elaborate set of rules for how those three buttons would interact in terms of when they'd be enabled/disabled, visible/invisible, when their labels would change, etc. It's complicated to describe, it would be complicated to implement, and I fail to see how it would simplify things for users. Therefore, I've implemented a much simpler solution with a single play/pause button that auto-stops at the designated mid-point in the interest of getting feedback on the simple solution before attempting to implement the more complicated one.