### PR TITLE
Training tweaks

### DIFF
--- a/src/code/models/simulation-control.ts
+++ b/src/code/models/simulation-control.ts
@@ -63,8 +63,8 @@ export const  SimulationControl = types.model(
     },
     enableTimer(endTime: Date) {
       const sleepMs = this.updateIntervalS * 1000;
-      let lastTime = new Date().getTime();
-      let newTime = new Date().getTime();
+      // let lastTime = new Date().getTime();
+      // let newTime;
 
       if (!this.isPlaying) {
         this._clearTimer();
@@ -73,9 +73,12 @@ export const  SimulationControl = types.model(
             this.stop();
           }
           else {
-            newTime = new Date().getTime();
-            const elapsedS = (newTime - lastTime) / 1000;
-            lastTime = newTime;
+            // newTime = new Date().getTime();
+            // this will skip increments if necessary to synchronize wall/simulation time
+            // const elapsedS = (newTime - lastTime) / 1000;
+            // lastTime = newTime;
+            // this will always increment by one second, even if simulation takes longer
+            const elapsedS = this.updateIntervalS;
             const simSeconds = elapsedS * this.timeScale;
             this.advanceTime({seconds: simSeconds});
           }

--- a/src/code/models/simulation-control.ts
+++ b/src/code/models/simulation-control.ts
@@ -3,8 +3,8 @@ import * as moment from 'moment';
 import { simulationStore } from '../models/simulation';
 
 const kOverrides = {
-  timeStep: 5,
-  timeScale: 300,
+  timeStep: 1,
+  timeScale: 60,
   updateIntervalS: 1
 };
 

--- a/src/code/models/simulation-settings.ts
+++ b/src/code/models/simulation-settings.ts
@@ -33,6 +33,7 @@ const kMetersPerSecToMPH = 2.23694,
 export const SimulationSettings = types.model('SimulationSettings', {
   id: types.optional(types.identifier(types.string), () => uuid()),
   showBaseMap: types.optional(types.boolean, true),
+  interpolationEnabled: types.optional(types.boolean, false),
   showTempColors: types.optional(types.boolean, false),
   showTempValues: types.optional(types.boolean, true),
   showDeltaTemp: types.optional(types.boolean, false),

--- a/src/code/models/simulation.ts
+++ b/src/code/models/simulation.ts
@@ -154,7 +154,7 @@ export const Simulation = types.model('Simulation', {
           if (!this.time) {
             this.setTime(startTime);
           }
-          station.setState(new WeatherStationState(stationData, this.control));
+          station.setState(new WeatherStationState(stationData, this.control, this.settings.interpolationEnabled));
         })
         .catch((err: any) => {
           console.log(`Error initializing weather station '${station.id}': ${err}`);

--- a/src/code/models/weather-station-state.ts
+++ b/src/code/models/weather-station-state.ts
@@ -9,11 +9,13 @@ export const kDefaultPrecision = {
 export class WeatherStationState {
   simulation: ISimulationControl;
   stationData: any;
+  interpolationEnabled: boolean;
   colIndices: { [key: string]: number; };
 
-  constructor(stationData: any, simulation: ISimulationControl) {
+  constructor(stationData: any, simulation: ISimulationControl, interpolationEnabled: boolean) {
     this.stationData = stationData;
     this.simulation = simulation;
+    this.interpolationEnabled = interpolationEnabled;
 
     this.colIndices = {};
     stationData.cols.forEach((name: string, index: number) => {
@@ -63,7 +65,9 @@ export class WeatherStationState {
     const lowTime = this.stationData.rows[indices.low][this.colIndices.time].getTime(),
           highTime = this.stationData.rows[indices.high][this.colIndices.time].getTime(),
           timeInterval = highTime - lowTime;
-    return timeInterval ? (simTime.getTime() - lowTime) / timeInterval : 0;
+    return this.interpolationEnabled && timeInterval
+              ? (simTime.getTime() - lowTime) / timeInterval
+              : 0;
   }
 
   interpolate(colIndex: number): number | null {

--- a/src/code/views/segmented-control-view.tsx
+++ b/src/code/views/segmented-control-view.tsx
@@ -42,6 +42,8 @@ export class SegmentedControlView extends React.Component<
     const isAtEnd = currentTime && endTime && currentTime >= endTime;
     const playPauseIcon = isPlaying ? "icon-pause" : "icon-play_arrow";
     const playPauseAction = isPlaying ? simulation.stop : simulation.play;
+    const skipToTime = simulation && currentTime < halfTime ? halfTime : endTime;
+    const skipAction = () => { if (skipToTime) { simulation.setTime(skipToTime); } };
     const style:ComponentStyleMap = {
       container: {
         display: "flex",
@@ -52,6 +54,9 @@ export class SegmentedControlView extends React.Component<
       },
       buttonStyle: {
         padding: "0 4px"
+      },
+      skipButtonStyle: {
+        marginLeft: 4
       },
       iconStyle: {
         color: "#FFF",
@@ -75,6 +80,14 @@ export class SegmentedControlView extends React.Component<
               onTouchTap={playPauseAction}
               icon={<i className={playPauseIcon} style={style.iconStyle} />}
               label={isPlaying ? "Pause" : "Play"}
+              primary={true}
+            />
+            <RaisedButton
+              buttonStyle={style.skipButtonStyle}
+              disabled={!simulation || isPlaying || isAtEnd}
+              onTouchTap={skipAction}
+              icon={<i className="icon-skip_next" style={style.iconStyle} />}
+              label={"Skip"}
               primary={true}
             />
           </div>

--- a/src/code/views/weather-station-view.tsx
+++ b/src/code/views/weather-station-view.tsx
@@ -23,7 +23,7 @@ export class WeatherStationView extends
 
   render() {
     let name = "";
-    let callSign = "";
+    // let callSign = "";
     const {weatherStation} = this.props;
     const simulation = simulationStore.selected;
     const time = simulation.timeString,
@@ -41,7 +41,7 @@ export class WeatherStationView extends
           // arrowChar = isNonZeroSpeed && windDirection ? "\u279B" : "\xA0";
     if (weatherStation) {
       name = weatherStation.name;
-      callSign = weatherStation.callSign;
+      // callSign = weatherStation.callSign;
     }
     // const color = weatherColor(weatherStation);
     const styles: ComponentStyleMap = {
@@ -84,14 +84,14 @@ export class WeatherStationView extends
         alignSelf: "flex-start"
       },
       temp: {
-        gridRow: "4",
+        gridRow: "3",
         gridColumn: "2",
         fontSize: "36pt",
         fontWeight: "bold",
         alignSelf: "center"
       },
       precip: {
-        gridRow: "5",
+        gridRow: "4",
         gridColumn: "2",
         fontSize: "36pt",
         fontWeight: "bold",
@@ -123,9 +123,9 @@ export class WeatherStationView extends
             <div style={styles.time}>
               {time}
             </div>
-            <div style={styles.callSign}>
+            {/* <div style={styles.callSign}>
               {callSign}
-            </div>
+            </div> */}
             <div style={styles.name}>
               {name}
             </div>


### PR DESCRIPTION
Final tweaks before tomorrow's teacher training, based on conversation with Tom.
- Add "Skip" button to simulation play controls
- Change playback speed to 1 minute wall time == 1 hour simulation time
- Eliminate location from body of student view
- Eliminate time interpolation, i.e. always advance simulation time by consistent increment
- Eliminate value (e.g. temperature) interpolation