### PR TITLE
Support test firebase instance; add student URL button

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "npaessel@concord.org",
   "license": "MIT",
   "dependencies": {
+    "clipboard": "^1.7.1",
     "firebase": "^4.9.0",
     "leaflet": "^1.0.3",
     "lodash": "^4.17.4",
@@ -46,6 +47,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
+    "@types/clipboard": "^1.5.36",
     "@types/jest": "^21.1.5",
     "@types/lodash": "^4.14.72",
     "@types/material-ui": "^0.20.5",

--- a/src/code/middleware/firebase-imp.ts
+++ b/src/code/middleware/firebase-imp.ts
@@ -1,7 +1,9 @@
 import * as firebase from "firebase";
+import { urlParams } from "../utilities/url-params";
 
 const DEFAULT_SIMULATION = "default";
 const DEFAULT_VERSION_STRING = "1.3.0-pre6";
+const kDatabaseSuffix = urlParams.isTesting ? '-test' : '';
 
 interface FirebaseListener {
   setState(state: any): void;
@@ -113,7 +115,8 @@ export class FirebaseImp {
   }
 
   get basePath() {
-    return DEFAULT_VERSION_STRING.replace(/\./g, "_");
+    const versionString = DEFAULT_VERSION_STRING.replace(/\./g, "_");
+    return `${versionString}${kDatabaseSuffix}`;
   }
 
   setDataRef() {

--- a/src/code/utilities/url-params.ts
+++ b/src/code/utilities/url-params.ts
@@ -1,0 +1,53 @@
+import * as queryString from "query-string";
+
+export interface StudentLaunchParams {
+  domain: string;
+  class_info_url: string;
+  domain_uid: string;
+  externalId: string;
+  logging: boolean;
+  returnUrl: string;
+}
+
+export interface TeacherReportParams {
+  offering: string;
+  token: string;
+}
+
+interface TestingParams {
+  student?: boolean | null;
+  test?: boolean | null;
+}
+
+type UnionParams = StudentLaunchParams | TeacherReportParams | TestingParams;
+
+function isPortalStudentParams(params: UnionParams): params is StudentLaunchParams {
+  return ((params as StudentLaunchParams).class_info_url != null);
+}
+
+function isPortalTeacherParams(params: UnionParams): params is TeacherReportParams {
+  return ((params as TeacherReportParams).offering != null);
+}
+
+// passing 'student' URL parameter indicates student -- for testing/debugging
+function hasStudentTestingParam(params: UnionParams): params is TestingParams {
+  return ((params as TestingParams).student !== undefined);
+}
+
+function hasTestTestingParam(params: UnionParams): params is TestingParams {
+  return ((params as TestingParams).test !== undefined);
+}
+
+const params = queryString.parse(window.location.search),
+      isPortalTeacher = isPortalTeacherParams(params),
+      isPortalStudent = !isPortalTeacher && isPortalStudentParams(params),
+      isStudent = isPortalStudent || hasStudentTestingParam(params),
+      isTeacher = !isStudent,
+      // if `test` URL parameter is present, or if we're not launched from portal,
+      // then we're testing, i.e. writing to `-test` database rather than production.
+      isTesting = hasTestTestingParam(params) || (!isPortalTeacher && !isPortalStudent);
+
+export const urlParams = {
+  params, isPortalTeacher, isPortalStudent, isTeacher, isStudent, isTesting
+};
+

--- a/src/code/views/teacher-view.tsx
+++ b/src/code/views/teacher-view.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as Clipboard from "clipboard";
 import { observer } from "mobx-react";
 import { Card, CardMedia, CardTitle } from "material-ui/Card";
 import { Tab, Tabs } from "material-ui/Tabs";
@@ -14,6 +15,7 @@ import { ComponentStyleMap } from "../utilities/component-style-map";
 
 import { IGridCell } from "../models/grid-cell";
 import { simulationStore } from "../models/simulation";
+import { urlParams } from "../utilities/url-params";
 
 
 // require("!style-loader!css-loader!react-treeview/react-treeview.css");
@@ -99,6 +101,8 @@ export class TeacherView extends React.Component<
                                   TeacherViewProps,
                                   TeacherViewState> {
 
+  clipboard: Clipboard;
+
   constructor(props: TeacherViewProps, ctxt: any) {
     super(props, ctxt);
     this.state = {
@@ -111,6 +115,18 @@ export class TeacherView extends React.Component<
           settings = simulation && simulation.settings;
     if (settings) {
       settings.setSetting('enabledPredictions', value);
+    }
+  }
+
+  componentDidMount() {
+    if (urlParams.isTesting && Clipboard.isSupported()) {
+      this.clipboard = new Clipboard('.clipboard-button');
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.clipboard) {
+      this.clipboard.destroy();
     }
   }
 
@@ -167,6 +183,15 @@ export class TeacherView extends React.Component<
   render() {
     const simulation = simulationStore.selected,
           time = simulation && simulation.timeString,
+          teacherUrl = window.location.href,
+          studentUrl = urlParams.isTesting
+                        ? teacherUrl.replace('show/teacher', 'show/student')
+                        : '',
+          studentUrlBtn = studentUrl
+                            ? <button className="clipboard-button" data-clipboard-text={studentUrl}>
+                                Copy student URL to clipboard
+                              </button>
+                            : null,
           userCount = simulation && simulation.presences.size,
           usersString = `${userCount} ${userCount === 1 ? 'user' : 'users'}`;
 
@@ -190,6 +215,7 @@ export class TeacherView extends React.Component<
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
                   <div>{simulation && simulation.name || ""}</div>
                   <div>{usersString}</div>
+                  {studentUrlBtn}
                 </div>
               </div>
             </CardTitle>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,10 @@ module.exports = {
       {
         test: /\.jsx?$/,
         loader: "babel-loader",
-        exclude: /node_modules/
+        include: [
+          path.resolve(__dirname, "src"),
+          path.resolve(__dirname, "node_modules/clipboard/src")
+        ],
       },
       // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
       { test: /\.tsx?$/, loader: "awesome-typescript-loader", options: {configFileName: "./tsconfig.json"} },

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,10 @@
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.6.tgz#a4b81ca8cdeb1acbc7923289a4a514f61b59db86"
 
+"@types/clipboard@^1.5.36":
+  version "1.5.36"
+  resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-1.5.36.tgz#e79fffc758e94e7ff9de9898ae7561db3c2bdd51"
+
 "@types/geojson@*":
   version "7946.0.0"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.0.tgz#e8bc74e8183d966455f82023f0c72e1072a952d0"
@@ -1633,6 +1637,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+clipboard@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -2163,6 +2175,10 @@ del@^3.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3102,6 +3118,12 @@ globby@^7.1.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
@@ -6040,6 +6062,10 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
 selfsigned@^1.9.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.1.tgz#bf8cb7b83256c4551e31347c6311778db99eec52"
@@ -6630,6 +6656,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
- Use `-test` firebase branch when testing or not launched from portal [#154646750]
- Support `test` URL parameter to indicate when testing instance should be used, e.g. on learn.staging
- Default to unique random simulation name/id when not launched from portal
Centralize URL parsing [#154605938]
- Add button to copy student URL to clipboard from teacher view (only when testing)
 [#154606426]
- Also addresses [#154065118]

The idea is to restrict the main firebase branch to be the production instance, only to be used when run from the learn portal, while all non-portal launches as well as portal launches with the `test` parameter use the `-test` branch as the staging instance. The generation of the unique random session ID makes it harder to bring "students" in when demoing, so the new button to "Copy student URL to clipboard" simplifies that process, but only when testing.

@scytacki Mentioning you in case you're interested in taking a look.