### PR TITLE
Simulation id/name includes offering; support offering/class external report types

### DIFF
--- a/src/code/models/simulation-metadata.ts
+++ b/src/code/models/simulation-metadata.ts
@@ -1,0 +1,21 @@
+import { types } from "mobx-state-tree";
+
+export const SimulationMetadata = types
+  .model('SimulationMetadata', {
+    launchOrigin: types.maybe(types.string),
+    classId: types.maybe(types.string),
+    offeringId: types.maybe(types.string),
+    offeringUrl: types.maybe(types.string),
+    activityName: types.maybe(types.string),
+    activityUrl: types.maybe(types.string),
+    launchTime: types.maybe(types.string),
+    utcLaunchTime: types.maybe(types.string)
+  });
+export type ISimulationMetadata = typeof SimulationMetadata.Type;
+export type ISimulationMetadataSnapshot = typeof SimulationMetadata.SnapshotType;
+
+// Temporary for use in getting metadata from main.tsx to Simulation.create()
+export let gSimulationMetadata = {};
+export function captureSimulationMetadata(metadata: ISimulationMetadataSnapshot) {
+  gSimulationMetadata = metadata;
+}

--- a/src/code/models/simulation.ts
+++ b/src/code/models/simulation.ts
@@ -1,5 +1,6 @@
 import { types } from "mobx-state-tree";
 import { SimulationControl } from "./simulation-control";
+import { SimulationMetadata, gSimulationMetadata } from "./simulation-metadata";
 import { SimulationSettings, IFormatTempOptions, IFormatWindSpeedOptions } from "../models/simulation-settings";
 import { IMapConfig } from "./map-config";
 import { gWeatherEvent } from "./weather-event";
@@ -25,8 +26,9 @@ const kBreakProportion = 0.75;
 
 export const Simulation = types
   .model('Simulation', {
-    name: types.optional(types.string,  () => "busted"),
+    name: types.optional(types.string,  () => "shall-not-be-named"),
     id: types.optional(types.identifier(types.string), () => uuid()),
+    metadata: types.optional(SimulationMetadata,   () => SimulationMetadata.create(gSimulationMetadata)),
     scenario: types.optional(WeatherScenario,      () => WeatherScenario.create(gWeatherScenarioSpec)),
     control: types.optional(SimulationControl,     () => SimulationControl.create()),
     settings: types.optional(SimulationSettings,   () => SimulationSettings.create()),

--- a/src/code/utilities/url-params.ts
+++ b/src/code/utilities/url-params.ts
@@ -21,6 +21,11 @@ interface TestingParams {
 
 type UnionParams = StudentLaunchParams | TeacherReportParams | TestingParams;
 
+function isTestingLaunchUrl() {
+  return ((window.location.hostname.indexOf('localhost') >= 0) ||
+          (window.location.hostname.indexOf('learn.staging') >= 0));
+}
+
 function isPortalStudentParams(params: UnionParams): params is StudentLaunchParams {
   return ((params as StudentLaunchParams).class_info_url != null);
 }
@@ -45,7 +50,8 @@ const params = queryString.parse(window.location.search),
       isTeacher = !isStudent,
       // if `test` URL parameter is present, or if we're not launched from portal,
       // then we're testing, i.e. writing to `-test` database rather than production.
-      isTesting = hasTestTestingParam(params) || (!isPortalTeacher && !isPortalStudent);
+      isTesting = isTestingLaunchUrl() || hasTestTestingParam(params) ||
+                    (!isPortalTeacher && !isPortalStudent);
 
 export const urlParams = {
   params, isPortalTeacher, isPortalStudent, isTeacher, isStudent, isTesting


### PR DESCRIPTION
- Simulation id/name includes offering ID [#154670197]
- Weather Dashboard external report button/link works for class and offering report types [#154670488]
- Store simulation metadata with simulation on creation
  - launchOrigin, classId, offeringId, offeringUrl, activityName, activityUrl, launchTime (local), utcLaunchTime
- `localhost` and `learn.staging` URLs use `-test` firebase branch (staging instance)

Once this is merged, the Weather Dashboard external report type can be changed to offering so that it only appears as a button (the class-wide link should no longer appear). Either is supported, however, so the report type doesn't have to be changed at the same instant the code is merged. 

@knowuh You're welcome to take a look, but for a change of pace I've assigned this one to @scytacki  for review.

Note that this PR is based on the previous PRs, but has been rebased on top of them.