### PR TITLE
Add more options button to teacher page

### DIFF
--- a/src/code/models/simulation.ts
+++ b/src/code/models/simulation.ts
@@ -255,6 +255,10 @@ export const Simulation = types
         const path =`simulations/${self.id}`;
         self.presences.deletePresence(path, presenceID);
       },
+      deleteAllOtherPresences() {
+        const path =`simulations/${self.id}`;
+        self.presences.deleteAllOtherPresences(path);
+      },
       // SimulationControl wrappers
       setTime(time: Date) {
         self.control.setTime(time);

--- a/src/code/views/copy-student-link-button.tsx
+++ b/src/code/views/copy-student-link-button.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import * as Clipboard from "clipboard";
+import IconButton from 'material-ui-next/IconButton';
+import SvgIcon from 'material-ui-next/SvgIcon';
+import Tooltip from 'material-ui-next/Tooltip';
+import { urlParams } from "../utilities/url-params";
+
+export const LinkIcon = (props: any) => {
+  // SVG from https://material.io/icons/#ic_link
+  // tslint:disable-next-line:max-line-length
+  const svgPath = "M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z";
+  return (
+    <SvgIcon {...props}>
+      <path d={svgPath}/>
+    </SvgIcon>
+  );
+};
+
+interface CopyStudentLinkButtonProps {
+}
+
+interface CopyStudentLinkButtonState {
+}
+
+export class CopyStudentLinkButton
+  extends React.Component<CopyStudentLinkButtonProps, CopyStudentLinkButtonState> {
+
+  clipboard: Clipboard;
+
+  componentDidMount() {
+    if (urlParams.isTesting && Clipboard.isSupported()) {
+      this.clipboard = new Clipboard('.copy-student-url-button');
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.clipboard) {
+      this.clipboard.destroy();
+    }
+  }
+
+  render() {
+    const teacherUrl = window.location.href,
+          studentUrl = urlParams.isTesting
+                        ? teacherUrl.replace('show/teacher', 'show/student')
+                        : '';
+    return (
+      <Tooltip id="tooltip-copy-student-url" title="Copy Student Link" placement="left">
+        <IconButton className="copy-student-url-button" aria-label="Copy"
+                    data-clipboard-text={studentUrl}>
+          <LinkIcon />
+        </IconButton>
+      </Tooltip>
+    );
+  }
+}

--- a/src/code/views/teacher-options-button.tsx
+++ b/src/code/views/teacher-options-button.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import IconButton from 'material-ui-next/IconButton';
+import SvgIcon from 'material-ui-next/SvgIcon';
+import Tooltip from 'material-ui-next/Tooltip';
+import { TeacherOptionsDrawer } from './teacher-options-drawer';
+
+export const MenuIcon = (props: any) => {
+  return (
+    <SvgIcon {...props}>
+      {/* SVG from https://material.io/icons/#ic_menu */}
+      <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
+    </SvgIcon>
+  );
+};
+
+interface TeacherOptionsButtonProps {
+}
+
+interface TeacherOptionsButtonState {
+  isTooltipOpen: boolean;
+  isDrawerOpen: boolean;
+}
+
+export class TeacherOptionsButton
+  extends React.Component<TeacherOptionsButtonProps, TeacherOptionsButtonState> {
+
+  isClosingDrawer: boolean;
+
+  state = {
+    isTooltipOpen: false,
+    isDrawerOpen: false
+  };
+
+  handleOpenTooltip = () => {
+    // prevent closing drawer from auto-opening the tooltip
+    if (!this.isClosingDrawer) {
+      this.setState({ isTooltipOpen: true });
+    }
+  }
+
+  handleCloseTooltip = () => {
+    this.setState({ isTooltipOpen: false });
+  }
+
+  handleOpenDrawer = () => {
+    this.setState({ isTooltipOpen: false, isDrawerOpen: true });
+  }
+
+  handleCloseDrawer = () => {
+    this.isClosingDrawer = true;
+    this.setState({ isTooltipOpen: false, isDrawerOpen: false });
+    setTimeout(() => this.isClosingDrawer = false, 250);
+  }
+
+  render() {
+    const { isTooltipOpen, isDrawerOpen } = this.state,
+          { handleOpenTooltip, handleCloseTooltip } = this;
+    return (
+      <div>
+        <Tooltip id="tooltip-more-options" title="More Options" placement="left"
+                  open={isTooltipOpen} onOpen={handleOpenTooltip} onClose={handleCloseTooltip} >
+          <IconButton className="teacher-menu-button" aria-label="Menu"
+                      aria-haspopup="true" onClick={this.handleOpenDrawer} >
+            <MenuIcon />
+          </IconButton>
+        </Tooltip>
+        <TeacherOptionsDrawer isOpen={isDrawerOpen} onClose={this.handleCloseDrawer} />
+      </div>
+    );
+  }
+}

--- a/src/code/views/teacher-options-drawer.tsx
+++ b/src/code/views/teacher-options-drawer.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import SvgIcon from 'material-ui-next/SvgIcon';
+import Drawer from 'material-ui-next/Drawer';
+import { ListItem, ListItemIcon, ListItemText } from 'material-ui-next/List';
+import { simulationStore } from "../models/simulation";
+
+export const DeleteSweepIcon = (props: any) => {
+  // SVG from https://material.io/icons/#ic_delete_sweep
+  // tslint:disable-next-line:max-line-length
+  const svgPath = "M15 16h4v2h-4zm0-8h7v2h-7zm0 4h6v2h-6zM3 18c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V8H3v10zM14 5h-3l-1-1H6L5 5H2v2h12z";
+  return (
+    <SvgIcon {...props}>
+      <path d={svgPath}/>
+    </SvgIcon>
+  );
+};
+
+interface TeacherOptionsDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface TeacherOptionsDrawerState {
+}
+
+export class TeacherOptionsDrawer
+  extends React.Component<TeacherOptionsDrawerProps, TeacherOptionsDrawerState> {
+
+  handleDisconnectAll = () => {
+    const simulation = simulationStore.selected;
+    if (simulation) {
+      simulation.deleteAllOtherPresences();
+    }
+  }
+
+  render() {
+    return (
+      <Drawer anchor="right" open={this.props.isOpen} onClose={this.props.onClose}>
+        <div tabIndex={0} role="button"
+            onClick={this.props.onClose} onKeyDown={this.props.onClose} >
+          <ListItem button onClick={this.handleDisconnectAll}>
+            <ListItemIcon>
+              <DeleteSweepIcon />
+            </ListItemIcon>
+            <ListItemText primary="Disconnect All" />
+          </ListItem>
+        </div>
+      </Drawer>
+    );
+  }
+}

--- a/src/code/views/teacher-view.tsx
+++ b/src/code/views/teacher-view.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as Clipboard from "clipboard";
 import { observer } from "mobx-react";
 import { Card, CardMedia, CardTitle } from "material-ui/Card";
 import { Tab, Tabs } from "material-ui/Tabs";
@@ -7,21 +6,16 @@ import { cityAnnotation } from "../utilities/city-map";
 import { GridView } from "./grid-view";
 import { weatherColor, precipDiv } from "./weather-styler";
 import { LeafletMapView } from "./leaflet-map-view";
-// import { PlaybackOptionsView } from "./playback-options-view";
-// import { PlaybackControlView } from "./playback-control-view";
 import { SegmentedControlView } from "./segmented-control-view";
 import { ComponentStyleMap } from "../utilities/component-style-map";
-//import { TeacherOptionsView } from "./teacher-options-view";
 
 import { cellName, IGridCell } from "../models/grid-cell";
 import { simulationStore } from "../models/simulation";
 import { urlParams } from "../utilities/url-params";
 import Popover from "material-ui-next/Popover";
 import { TeacherCellPopover } from "./teacher-cell-popover";
-
-
-// require("!style-loader!css-loader!react-treeview/react-treeview.css");
-// require("!style-loader!css-loader!../../html/treeview.css");
+import { TeacherOptionsButton } from "./teacher-options-button";
+import { CopyStudentLinkButton } from "./copy-student-link-button";
 
 export type TeacherViewTab = "control" | "configure";
 export const MAP_TYPE_GRID = "MAP_TYPE_GRID";
@@ -106,11 +100,9 @@ const styles:ComponentStyleMap = {
 };
 
 @observer
-export class TeacherView extends React.Component<
-                                  TeacherViewProps,
-                                  TeacherViewState> {
+export class TeacherView
+  extends React.Component<TeacherViewProps, TeacherViewState> {
 
-  clipboard: Clipboard;
   closingCount: number;
 
   constructor(props: TeacherViewProps, ctxt: any) {
@@ -128,18 +120,6 @@ export class TeacherView extends React.Component<
           settings = simulation && simulation.settings;
     if (settings) {
       settings.setSetting('enabledPredictions', value);
-    }
-  }
-
-  componentDidMount() {
-    if (urlParams.isTesting && Clipboard.isSupported()) {
-      this.clipboard = new Clipboard('.clipboard-button');
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.clipboard) {
-      this.clipboard.destroy();
     }
   }
 
@@ -246,17 +226,11 @@ export class TeacherView extends React.Component<
   render() {
     const simulation = simulationStore.selected,
           time = simulation && simulation.timeString,
-          teacherUrl = window.location.href,
-          studentUrl = urlParams.isTesting
-                        ? teacherUrl.replace('show/teacher', 'show/student')
-                        : '',
-          studentUrlBtn = studentUrl
-                            ? <button className="clipboard-button" data-clipboard-text={studentUrl}>
-                                Copy student URL to clipboard
-                              </button>
-                            : null,
           userCount = simulation && simulation.presences.size,
-          usersString = `${userCount} ${userCount === 1 ? 'user' : 'users'}`;
+          usersString = `${userCount} ${userCount === 1 ? 'user' : 'users'}`,
+          copyStudentUrlButton = urlParams.isTesting
+                                  ? <CopyStudentLinkButton />
+                                  : null;
 
     const handleChangeTab = (value: TeacherViewTab) => {
       this.setState({
@@ -267,18 +241,20 @@ export class TeacherView extends React.Component<
     return (
       <Card>
         <Tabs value={this.state.tab} onChange={handleChangeTab}>
-          {/* <Tab label="Options" value="configure">
-            <PlaybackOptionsView />
-            <TeacherOptionsView />
-          </Tab> */}
           <Tab label="Control" value="control">
             <CardTitle>
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <div style={{ fontWeight: 'bold', fontSize: "14pt"}}> {time}</div>
+              <div className="teacher-title-card-contents"
+                    style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <div style={{ fontWeight: 'bold', fontSize: "14pt"}}>{time}</div>
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
                   <div>{simulation && simulation.name || ""}</div>
-                  <div>{usersString}</div>
-                  {studentUrlBtn}
+                  <div className="teacher-status-options">
+                    <div>{usersString}</div>
+                    <div className="teacher-option-buttons">
+                      {copyStudentUrlButton}
+                      <TeacherOptionsButton />
+                    </div>
+                  </div>
                 </div>
               </div>
             </CardTitle>
@@ -289,21 +265,11 @@ export class TeacherView extends React.Component<
                 alignItems: "center"
               }}
             >
-              <div style={styles.wrapper}>
-                <div style={styles.mapAndPrediction}>
+              <div className="teacher-card-media-wrapper" style={styles.wrapper}>
+                <div className="teacher-card-media-map" style={styles.mapAndPrediction}>
                     { this.renderMapView() }
-                  {/*
-                    import { PredictionDisplayView } from "../prediction-display-view"
-                    <PredictionDisplayView />
-                  */}
                 </div>
                   <SegmentedControlView />
-                  {/* <PlaybackControlView /> */}
-                {/*
-                  import { PredictionSelectorView } from "../prediction-selection-view"
-                  <PredictionSelectorView />
-                */}
-
               </div>
             </CardMedia>
           </Tab>

--- a/src/html/weather.css
+++ b/src/html/weather.css
@@ -99,6 +99,21 @@ table.GridView td.set {
   margin-top: 8px;
 }
 
+.teacher-status-options {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.teacher-option-buttons {
+  display: flex;
+  flex-direction: row;
+}
+
+.teacher-card-media-wrapper {
+  margin-top: -30px;
+}
+
 .weather-station-exit-button button {
   position: absolute !important;
   bottom: 0px;


### PR DESCRIPTION
Add more options button to teacher page
- drawer slides out from right side with options:
  - `Disconnect All` item disconnects all student presences [#154671568]
- replace `Copy Student URL` button with icon button with tooltip

Note: I tried to put the "Copy Student Link" button in the drawer, but it doesn't work there for some reason and it didn't seem worth spending more time trying to get it to work given that it's a testing-only option. The drawer currently seems a little lonely with just the one "Disconnect All" item there, but I have a feeling that we'll come up with more options to go there over time.