### PR TITLE
Unique-to-offering simulation names; handle launch errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "clipboard": "^1.7.1",
     "firebase": "^4.9.0",
+    "jsonwebtoken": "^8.1.1",
     "leaflet": "^1.0.3",
     "lodash": "^4.17.4",
     "material-ui": "^0.20.0",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@types/clipboard": "^1.5.36",
     "@types/jest": "^21.1.5",
+    "@types/jsonwebtoken": "^7.2.5",
     "@types/lodash": "^4.14.72",
     "@types/material-ui": "^0.20.5",
     "@types/query-string": "^5.0.1",

--- a/src/code/utilities/url-params.ts
+++ b/src/code/utilities/url-params.ts
@@ -2,11 +2,8 @@ import * as queryString from "query-string";
 
 export interface StudentLaunchParams {
   domain: string;
-  class_info_url: string;
   domain_uid: string;
-  externalId: string;
-  logging: boolean;
-  returnUrl: string;
+  token: string;
 }
 
 export interface TeacherReportParams {
@@ -27,7 +24,7 @@ function isTestingLaunchUrl() {
 }
 
 function isPortalStudentParams(params: UnionParams): params is StudentLaunchParams {
-  return ((params as StudentLaunchParams).class_info_url != null);
+  return ((params as StudentLaunchParams).domain != null) && !isPortalTeacherParams(params);
 }
 
 function isPortalTeacherParams(params: UnionParams): params is TeacherReportParams {

--- a/src/code/views/portal-view.tsx
+++ b/src/code/views/portal-view.tsx
@@ -22,6 +22,10 @@ export interface PortalViewProps {
 export interface PortalViewState {
   simulationKey: string;
   showTeacher: boolean;
+  startTitle: string;
+  startMessage: string;
+  startDetail?: string;
+  startSuggestion?: string;
 }
 
 @observer
@@ -32,7 +36,12 @@ class _PortalView extends React.Component<
   constructor(props: PortalViewProps, ctx: any) {
     super(props);
     // default to teacher
-    this.state = {simulationKey: defaultSimulationName, showTeacher: true};
+    this.state = {
+      simulationKey: defaultSimulationName,
+      showTeacher: true,
+      startTitle: "Start Simulation",
+      startMessage: "Waiting for simulation to begin..."
+    };
   }
 
   componentDidMount() {
@@ -71,6 +80,14 @@ class _PortalView extends React.Component<
             ref.on('value', handleSnapshot);
           });
       }
+    })
+    .catch((error) => {
+      this.setState({
+        startTitle: "Error",
+        startMessage: `Could not start the simulation because an error occurred.`,
+        startDetail: `[${error.message}]`,
+        startSuggestion: "Try relaunching the simulation from the portal."
+      });
     });
   }
 
@@ -80,11 +97,19 @@ class _PortalView extends React.Component<
   }
 
   render() {
+    const { startTitle, startMessage, startDetail, startSuggestion } = this.state,
+          detail = startDetail ? <div>{startDetail}</div> : null,
+          spacer = startSuggestion ? <div>{"\u00A0"}</div> : null,
+          suggestion = startSuggestion ? <div>{startSuggestion}</div> : null;
     return (
       <Card>
-        <CardTitle>Start Simulation</CardTitle>
+        <CardTitle>{startTitle}</CardTitle>
         <CardText style={{}}>
-          Waiting for simulation to begin...
+          {startMessage}
+          {detail}
+          {spacer}
+          {spacer}
+          {suggestion}
         </CardText>
       </Card>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,12 @@
   version "21.1.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.10.tgz#dcacb5217ddf997a090cc822bba219b4b2fd7984"
 
+"@types/jsonwebtoken@^7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz#413159d570ec45fc3e7da7ea3f7bca6fb9300e72"
+  dependencies:
+    "@types/node" "*"
+
 "@types/jss@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.3.0.tgz#0f8484fd03ded206917be27b58217f274a0ad59f"
@@ -1202,6 +1208,10 @@ base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
 
+base64url@2.0.0, base64url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1417,6 +1427,10 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -2331,6 +2345,13 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+ecdsa-sig-formatter@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz#4bc926274ec3b5abb5016e7e1d60921ac262b2a1"
+  dependencies:
+    base64url "^2.0.0"
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -4253,6 +4274,21 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonwebtoken@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.1.1.tgz#b04d8bb2ad847bc93238c3c92170ffdbdd1cb2ea"
+  dependencies:
+    jws "^3.1.4"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    xtend "^4.0.1"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -4340,6 +4376,23 @@ jsx-ast-utils@^2.0.0:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+jwa@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.5.tgz#a0552ce0220742cd52e153774a32905c30e756e5"
+  dependencies:
+    base64url "2.0.0"
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.9"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.4.tgz#f9e8b9338e8a847277d6444b1464f61880e050a2"
+  dependencies:
+    base64url "^2.0.0"
+    jwa "^1.1.4"
+    safe-buffer "^5.0.1"
 
 keycode@^2.1.8, keycode@^2.1.9:
   version "2.1.9"
@@ -4468,6 +4521,30 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -4475,6 +4552,10 @@ lodash.memoize@^4.1.2:
 lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -4850,6 +4931,10 @@ ms@0.7.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -7439,7 +7524,7 @@ xmlhttprequest@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Support unique-to-offering simulation names [#155008052]
- support launching with JWT
- students extract offering_id from JWT
- put up appropriate error message if launch request fails for students or teachers [#154775798]

JWTs are only used for extracting the offering_id at the moment, but this is a first step toward using them for authentication as well.

This PR only modifies the student launch to use JWTs. The teacher launch is handled as an external report, which appears not to support JWTs as fully as the student launch: url params include offering but not domain and the JWT does not contain some potentially useful information that the student JWT contains like the class_info_url and the offering_id. For now we stick with extracting what we need from the offering.