### PR TITLE
162247556 new weather events

### DIFF
--- a/src/code/views/weather-styler.tsx
+++ b/src/code/views/weather-styler.tsx
@@ -23,9 +23,15 @@ export function precipDiv(station?:IWeatherStation|null) {
   const raining = station && station.precipitation;
   const fontColor = raining ? rainColor : sunColor;
   const style: React.CSSProperties = { position: 'relative', zIndex: 2, color: fontColor };
-  const rainIcon = "icon-cloud-rain";
+  const rainIcons = [
+    "",
+    "icon-cloud",
+    "icon-cloud-drizzle",
+    "icon-cloud-rain"]
+    ;
   // const sunIcon = "icon-sun";
-  const sunIcon = "";
-  const className = raining ?  rainIcon : sunIcon;
+  const index = station && station.precipitation ? station.precipitation : 0;
+  const className = rainIcons[index];
+  // return ( <span>{station.precipitation}</span> );
   return ( <i className={className} style={style} /> );
 }

--- a/src/json/weather-scenario-specs.json
+++ b/src/json/weather-scenario-specs.json
@@ -1,5 +1,116 @@
 [
   {
+    "id": "AK_EP2",
+    "name": "Alaska Episode 2",
+    "eventUrl": "https://raw.githubusercontent.com/concord-consortium/weather-events/master/events/AK_EP2.json",
+    "startTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 7,
+      "minute": 0
+    },
+    "endTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 19,
+      "minute": 0
+    },
+    "utcOffset": 0,
+    "mapConfig": {
+      "id": "AK_EP2",
+      "lat": 42,
+      "long": -77,
+      "name": "AK_EP2",
+      "zoom": 6
+    },
+    "stations": []
+  },
+  {
+    "id": "AK_EP1",
+    "name": "Alaska Episode 1",
+    "eventUrl": "https://raw.githubusercontent.com/concord-consortium/weather-events/master/events/AK_EP1.json",
+    "startTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 7,
+      "minute": 0
+    },
+    "endTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 19,
+      "minute": 0
+    },
+    "utcOffset": 0,
+    "mapConfig": {
+      "id": "AK_EP1",
+      "lat": 42,
+      "long": -77,
+      "name": "AK_EP1",
+      "zoom": 6
+    },
+    "stations": []
+  },
+  {
+    "id": "NE_EP2",
+    "name": "New England Episode 2",
+    "eventUrl": "https://raw.githubusercontent.com/concord-consortium/weather-events/master/events/NE_EP2.json",
+    "startTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 7,
+      "minute": 0
+    },
+    "endTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 19,
+      "minute": 0
+    },
+    "utcOffset": 0,
+    "mapConfig": {
+      "id": "NE_EP2",
+      "lat": 42,
+      "long": -77,
+      "name": "NE_EP2",
+      "zoom": 6
+    },
+    "stations": []
+  },{
+    "id": "NE_EP1",
+    "name": "New England Episode 1",
+    "eventUrl": "https://raw.githubusercontent.com/concord-consortium/weather-events/master/events/NE_EP1.json",
+    "startTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 7,
+      "minute": 0
+    },
+    "endTime": {
+      "year": 2013,
+      "month": 5,
+      "day": 15,
+      "hour": 19,
+      "minute": 0
+    },
+    "utcOffset": 0,
+    "mapConfig": {
+      "id": "NE_EP1",
+      "lat": 42,
+      "long": -77,
+      "name": "NE_EP1",
+      "zoom": 6
+    },
+    "stations": []
+  },
+  {
     "id": "day-one-v7",
     "name": "Day One (v7)",
     "eventUrl": "https://raw.githubusercontent.com/concord-consortium/weather-events/master/events/day-one-v7.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7412,12 +7412,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-style-loader@^0.23.1:
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
+style-loader@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.14.1.tgz#27b9b6c9822adf8c4748e02a1efae229405d79a5"
   dependencies:
-    loader-utils "^1.1.0"
-    schema-utils "^1.0.0"
+    loader-utils "^1.0.2"
 
 subarg@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Changes to support new weather events.

NOTE: The new weather spec uses precipitation values from 0-4.  We try to use font-icons to represent those. We will need better icons, and might need to think about backwards compatibility for day-1 activities?

The other change is the creation of 4 new weather scenario configurations. Two simulations each for New England and Alaska.  EP1 is temperature only, EP2 is temperature, moisture, and precipitation.

These new weather events were imported from excel spreadsheets. You can find the raw spreadsheets in the repo `weather-events` in the `/john-events` directory.  There is a new script to convert Johns spreadsheets too in `scripts/john-ep-importer.js`.

TODO:  How can we specify which weather scenario we use.  Right now we just always use the first weather scenario defined in `weather-scenario-specs.json`

TODO:  The simulation data is supposed to be in F degrees for these two simulations.  In our previous work (day-one) we used C degrees.

TODO: Display moisture values.

TODO: Add base-maps from the repo `weather-events` in the `/john-events` directory.


