### PR TITLE
Fixed presence refs to use paths that convert underscore to slash

### DIFF
--- a/src/code/middleware/firebase-imp.ts
+++ b/src/code/middleware/firebase-imp.ts
@@ -234,7 +234,7 @@ export class FirebaseImp {
   }
 
   refForPath(path:string) {
-    return new Promise( (resolve, reject) => {
+    return new Promise<firebase.database.Reference>( (resolve, reject) => {
       this.postConnect.then( (imp) => {
         resolve(imp.dataRef.child(path.replace(/_/g, "/")));
       });

--- a/src/code/stores/presence-store.ts
+++ b/src/code/stores/presence-store.ts
@@ -46,28 +46,25 @@ export const PresenceStore = types
       const firebase = gFirebase;
       const presence = Presence.create(snapshot);
       const path = `${_path}/presences/presences/${snapshot.id}`;
-      const presref = firebase.dataRef.child(path);
-      presref.onDisconnect().remove();
+      firebase.refForPath(path).then((presref) => presref.onDisconnect().remove());
       // add presence to map
       self.presences.put(presence);
       return presence;
     },
     deletePresence(_path: string, presenceID: string) {
-      const path = `${_path}/presences/presences/${presenceID}`,
-            presenceRef = gFirebase.dataRef.child(path);
-      if (presenceRef) {
-        presenceRef.set(null);
-      }
+      const path = `${_path}/presences/presences/${presenceID}`;
+      gFirebase.refForPath(path).then((presenceRef) => presenceRef.set(null));
     },
     deleteAllOtherPresences(_path: string) {
       const selfPresence = self.selected,
             selfPresenceID = selfPresence && selfPresence.id,
             selfPresenceSnapshot = selfPresence && getSnapshot(selfPresence);
       if (selfPresenceID) {
-        const path = `${_path}/presences/presences`,
-              presencesRef = gFirebase.dataRef.child(path),
-              presences = { [selfPresenceID]: selfPresenceSnapshot };
-        presencesRef.set(presences);
+        const path = `${_path}/presences/presences`;
+        gFirebase.refForPath(path).then((presencesRef) => {
+          const presences = { [selfPresenceID]: selfPresenceSnapshot };
+          presencesRef.set(presences);
+        });
       }
     }
   }));


### PR DESCRIPTION
This bug was causing the presences not to be set in the correct location in the tree as the underscores in the simulation id were not being first converted to forward slashes.