### PR TITLE
163596526 better disconnect handling

### DIFF
--- a/src/code/utilities/refresh-button.tsx
+++ b/src/code/utilities/refresh-button.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export class RefreshButton extends React.Component<{}, {}> {
+  render() {
+    const refresh = () => {window.location.reload();};
+    const buttonStyle:React.CSSProperties = {
+      fontWeight: "bold"
+    };
+    return(
+      <div>
+        Simulation has disconnected. Refresh to continue.
+          <button type="button"
+                  style={buttonStyle}
+                  onClick={refresh}>
+            Refresh
+          </button>
+      </div>
+    );
+  }
+}

--- a/src/code/views/choose-cell-view.tsx
+++ b/src/code/views/choose-cell-view.tsx
@@ -17,7 +17,6 @@ export interface ChooseCellStsate {
   chosenCell: IGridCell | null;
 }
 
-
 @observer
 export class ChooseCellView
   extends React.Component<ChooseCellProps, ChooseCellStsate> {
@@ -26,8 +25,10 @@ export class ChooseCellView
     this.state = {chosenCell: null};
   }
 
-
-  renderChooseButton(chosenCell?:IGridCell|null) {
+  renderChooseButton(chosenCell?:IGridCell|null, presence?: IPresence|null) {
+    if (!presence) {
+      return(<div>The simulation has disconnected - please refresh.</div>);
+    }
     if(!chosenCell) { return <div/>; }
     const style:React.CSSProperties = {
       color: "white",
@@ -97,7 +98,7 @@ export class ChooseCellView
             titleFunc={titleFunc}
             onCellClick={onClick}
             rollOverFunc={ (cell) => cell &&  cell.displayName}/>
-            {this.renderChooseButton(chosenCell) }
+            {this.renderChooseButton(chosenCell, presence)}
         </CardText>
       </div>
     );

--- a/src/code/views/choose-cell-view.tsx
+++ b/src/code/views/choose-cell-view.tsx
@@ -7,6 +7,7 @@ import { simulationStore } from "../models/simulation";
 import { IGridCell } from "../models/grid-cell";
 import { IPresence } from "../models/presence";
 import { GridView } from "./grid-view";
+import { RefreshButton } from "../utilities/refresh-button";
 
 import * as _ from "lodash";
 
@@ -26,8 +27,12 @@ export class ChooseCellView
   }
 
   renderChooseButton(chosenCell?:IGridCell|null, presence?: IPresence|null) {
+    // It is possible that between the time the student has selected a
+    // group from the pull down, and they go to click on the "choose"
+    // button, that the teacher could have disconnected them. If so, we
+    // display a message and present a button to reload the page.
     if (!presence) {
-      return(<div>The simulation has disconnected - please refresh.</div>);
+      return(<RefreshButton />);
     }
     if(!chosenCell) { return <div/>; }
     const style:React.CSSProperties = {

--- a/src/code/views/choose-group-view.tsx
+++ b/src/code/views/choose-group-view.tsx
@@ -87,6 +87,11 @@ export class ChooseGroupView
   }
 
   renderChooseButton() {
+    const simulation = simulationStore.selected;
+    const presence = simulation && simulation.selectedPresence;
+    if (!presence) {
+      return(<div>The simulation has disconnected - please refresh.</div>);
+    }
     if(this.state.chosenGroup === "") { return <div/>; }
     const style = styles.chooseButton;
     const {onDone} = this.props;

--- a/src/code/views/choose-group-view.tsx
+++ b/src/code/views/choose-group-view.tsx
@@ -8,6 +8,7 @@ import MenuItem from 'material-ui/MenuItem';
 import {IGroup} from "../models/group";
 import { simulationStore } from "../models/simulation";
 import { ComponentStyleMap } from "../utilities/component-style-map";
+import { RefreshButton } from "../utilities/refresh-button";
 
 export type StationTab = "configure" | "weather";
 
@@ -90,7 +91,11 @@ export class ChooseGroupView
     const simulation = simulationStore.selected;
     const presence = simulation && simulation.selectedPresence;
     if (!presence) {
-      return(<div>The simulation has disconnected - please refresh.</div>);
+      // It is possible that between the time the student has selected a
+      // group from the pull down, and they go to click on the "choose"
+      // button, that the teacher could have disconnected them. If so, we
+      // display a message and present a button to reload the page.
+      return(<RefreshButton />);
     }
     if(this.state.chosenGroup === "") { return <div/>; }
     const style = styles.chooseButton;


### PR DESCRIPTION
Now detects the "disconnect" situations in two spots where things get confusing for the student. See the PT story (Better Disconnect Handling)[https://www.pivotaltracker.com/story/show/163596526] for more details.

This is a bare-bones fix with minimal styling. Although styling would make the message presentation looks more consistent with the app's UI, this is a rare enough of an event that this simple text-message and "refresh" button may be adequate. 